### PR TITLE
fix: order zero for one correctly

### DIFF
--- a/src/CorkHook.sol
+++ b/src/CorkHook.sol
@@ -545,13 +545,16 @@ contract CorkHook is BaseHook, Ownable, ICorkHook {
         amountIn = SwapMath.getAmountIn(amountOut, reserveIn, reserveOut, invariant, oneMinusT, self.fee);
     }
 
-    function getAmountIn(address ra, address ct, bool zeroForOne, uint256 amountOut)
+    function getAmountIn(address ra, address ct, bool raForCt, uint256 amountOut)
         external
         view
         onlyInitialized(ra, ct)
         returns (uint256 amountIn)
     {
         (address token0, address token1) = sort(ra, ct);
+        // infer zero to one
+        bool zeroForOne = raForCt ? (token0 == ra) : (token0 == ct);
+
         PoolState storage self = pool[toAmmId(token0, token1)];
 
         amountIn = _getAmountIn(self, zeroForOne, amountOut);
@@ -577,13 +580,16 @@ contract CorkHook is BaseHook, Ownable, ICorkHook {
         amountOut = SwapMath.getAmountOut(amountIn, reserveIn, reserveOut, invariant, oneMinusT, self.fee);
     }
 
-    function getAmountOut(address ra, address ct, bool zeroForOne, uint256 amountIn)
+    function getAmountOut(address ra, address ct, bool raForCt, uint256 amountIn)
         external
         view
         onlyInitialized(ra, ct)
         returns (uint256 amountOut)
     {
         (address token0, address token1) = sort(ra, ct);
+        // infer zero to one
+        bool zeroForOne = raForCt ? (token0 == ra) : (token0 == ct);
+
         PoolState storage self = pool[toAmmId(token0, token1)];
 
         amountOut = _getAmountOut(self, zeroForOne, amountIn);

--- a/src/interfaces/ICorkHook.sol
+++ b/src/interfaces/ICorkHook.sol
@@ -38,12 +38,12 @@ interface ICorkHook is IErrors {
         view
         returns (uint256 baseFeePercentage, uint256 actualFeePercentage);
 
-    function getAmountIn(address ra, address ct, bool zeroForOne, uint256 amountOut)
+    function getAmountIn(address ra, address ct, bool raForCt, uint256 amountOut)
         external
         view
         returns (uint256 amountIn);
 
-    function getAmountOut(address ra, address ct, bool zeroForOne, uint256 amountIn)
+    function getAmountOut(address ra, address ct, bool raForCt, uint256 amountIn)
         external
         view
         returns (uint256 amountOut);


### PR DESCRIPTION
# Changes

List of Changes:
 - now order zero for one correctly when getting amount in and out in the hook